### PR TITLE
Only check sender if truthy, otherwise use default

### DIFF
--- a/recruiter-email.js
+++ b/recruiter-email.js
@@ -12,7 +12,7 @@ var RecruiterEmail = function(recipient, sender) {
 
     recipient = recipient || 'Person Who Showed Up In a LinkedIn Search';
 
-    if (typeof(sender) !== 'object') {
+    if (sender && typeof(sender) !== 'object') {
         console.log('sender argument must be an object');
         return false;
     }


### PR DESCRIPTION
If the sender is not passed in, the condition doesn't catch, and the default sender info is actually used.